### PR TITLE
Package Script & Versioning Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
-  "version": "0.0.1",
+  "name": "@developertown/use-bluetooth-notifications",
+  "author": "Matt Williams",
+  "version": "0.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "module": "dist/use-bluetooth-notifications.esm.js",
   "files": [
     "dist",
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
+    "test:watch": "react-scripts test",
     "lint": "tsdx lint",
     "prepare": "tsdx build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": ">=16.8.0"
   },
   "husky": {
     "hooks": {
       "pre-commit": "tsdx lint"
     }
   },
-  "name": "@developertown/use-bluetooth-notifications",
-  "author": "Matt Williams",
-  "module": "dist/use-bluetooth-notifications.esm.js",
   "devDependencies": {
     "@babel/core": "^7.9.6",
     "@storybook/react": "^5.3.18",


### PR DESCRIPTION
Update minimum node version and min react version peer dependency. Set tests to not watch by default and added separate watch task to allow publishing to work better